### PR TITLE
Fix command signature for make:wizard-step example

### DIFF
--- a/content/commands.md
+++ b/content/commands.md
@@ -54,7 +54,7 @@ To create a new step for an existing wizard, you can use the `make:wizard-step` 
 <code-tab>
 
 ```
-php artisan make:wizard ChooseSubscriptionStep RegistrationWizard
+php artisan make:wizard-step ChooseSubscriptionStep RegistrationWizard
 ```
 
 </code-tab>


### PR DESCRIPTION
The example for `make:wizard-step` used the `make:wizard` command, this PR resolves the issue.